### PR TITLE
django deprication warning is fixed for django==1.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.pyc
 /build/
 /dist/

--- a/screamshot/urls.py
+++ b/screamshot/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from views import capture
 


### PR DESCRIPTION
DeprecationWarning: django.conf.urls.defaults is deprecated; use django.conf.urls instead DeprecationWarning)
