### PR TITLE
TEST_CAPTURE_SCRIPT

### DIFF
--- a/screamshot/__init__.py
+++ b/screamshot/__init__.py
@@ -10,4 +10,5 @@ app_settings = dict({
     'CASPERJS_CMD': None,
     'PHANTOMJS_CMD': None,
     'SCREAMSHOT_AS_INSTANCE': False,
+    'TEST_CAPTURE_SCRIPT': True,
 }, **getattr(settings, 'SCREAMSHOT_CONFIG', {}))

--- a/screamshot/utils.py
+++ b/screamshot/utils.py
@@ -67,17 +67,19 @@ def casperjs_command():
             if os.path.exists(cmd):
                 break
     cmd = [cmd]
-    try:
-        proc = subprocess.Popen(cmd + ['--version'], **casperjs_command_kwargs())
-        proc.communicate()
-        status = proc.returncode
-        assert status == 0
-    except OSError:
-        msg = "%s binary cannot be found in PATH (%s)" % (method, sys_path)
-        raise ImproperlyConfigured(msg)
-    except AssertionError:
-        msg = "%s returned status code %s" % (method, status)
-        raise ImproperlyConfigured(msg)
+
+    if app_settings['TEST_CAPTURE_SCRIPT']:
+        try:
+            proc = subprocess.Popen(cmd + ['--version'], **casperjs_command_kwargs())
+            proc.communicate()
+            status = proc.returncode
+            assert status == 0
+        except OSError:
+            msg = "%s binary cannot be found in PATH (%s)" % (method, sys_path)
+            raise ImproperlyConfigured(msg)
+        except AssertionError:
+            msg = "%s returned status code %s" % (method, status)
+            raise ImproperlyConfigured(msg)
 
     # Add extra CLI arguments
     cmd += app_settings['CLI_ARGS']


### PR DESCRIPTION
Introducing `TEST_CAPTURE_SCRIPT` setting, which, when set to `False`, won't test the capture command by running it during app initialization. The default behavior remains the same, that is, `TEST_CAPTURE_SCRIPT` defaults to `True`.

Fixes #39.